### PR TITLE
Trigger runs for other pkgdb events.

### DIFF
--- a/fedmsg_genacls.py
+++ b/fedmsg_genacls.py
@@ -21,8 +21,14 @@ class GenACLsConsumer(fedmsg.consumers.FedmsgConsumer):
     topic = '*'
     interesting_topics = [
         'org.fedoraproject.prod.pkgdb.acl.update',
+        'org.fedoraproject.prod.pkgdb.acl.delete',
         'org.fedoraproject.prod.fas.group.member.sponsor',
         'org.fedoraproject.prod.fas.group.member.remove',
+        'org.fedoraproject.prod.pkgdb.package.new',
+        'org.fedoraproject.prod.pkgdb.package.delete',
+        'org.fedoraproject.prod.pkgdb.package.branch.new',
+        'org.fedoraproject.prod.pkgdb.package.branch.delete',
+        'org.fedoraproject.prod.pkgdb.owner.update',
     ]
 
     config_key = 'genacls.consumer.enabled'


### PR DESCRIPTION
This should fix #3 by making the genacls jobs run whenever there is a new
package added to pkgdb (as well as on some other events like branch creation
and deletion).
