### PR TITLE
genacls.sh needs to be run as root

### DIFF
--- a/fedmsg_genacls.py
+++ b/fedmsg_genacls.py
@@ -61,7 +61,7 @@ class GenACLsConsumer(fedmsg.consumers.FedmsgConsumer):
     def action(self, messages):
         self.log.debug("Acting on %s" % pprint.pformat(messages))
 
-        command = '/usr/bin/sudo -u root /usr/local/bin/genacls.sh'.split()
+        command = '\/usr/bin/sudo -u root \/usr/local/bin/genacls.sh'.split()
 
         self.log.info("Running %r" % command)
         process = subprocess.Popen(args=command)

--- a/fedmsg_genacls.py
+++ b/fedmsg_genacls.py
@@ -61,7 +61,7 @@ class GenACLsConsumer(fedmsg.consumers.FedmsgConsumer):
     def action(self, messages):
         self.log.debug("Acting on %s" % pprint.pformat(messages))
 
-        command = '/usr/bin/sudo -u gen-acls /usr/local/bin/genacls.sh'.split()
+        command = '/usr/bin/sudo -u root /usr/local/bin/genacls.sh'.split()
 
         self.log.info("Running %r" % command)
         process = subprocess.Popen(args=command)

--- a/fedmsg_genacls.py
+++ b/fedmsg_genacls.py
@@ -61,7 +61,7 @@ class GenACLsConsumer(fedmsg.consumers.FedmsgConsumer):
     def action(self, messages):
         self.log.debug("Acting on %s" % pprint.pformat(messages))
 
-        command = '\/usr/bin/sudo -u root \/usr/local/bin/genacls.sh'.split()
+        command = '/usr/bin/sudo -u root /usr/local/bin/genacls.sh'.split()
 
         self.log.info("Running %r" % command)
         process = subprocess.Popen(args=command)


### PR DESCRIPTION
We handle the permission at the sudo level but genacls.sh needs to be run as
root as it needs to be able to run chown and chroot commands.